### PR TITLE
Fix for the plugin failing to resolve proto files on Windows

### DIFF
--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -198,7 +198,9 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
     Optional<Map.Entry<Path, Path>> directoryEntry = directories.entrySet().stream().filter(d -> Files.exists(d.getValue().resolve(proto))).findFirst();
 
     if (directoryEntry.isEmpty()) {
-      if (CoreLoader.INSTANCE.isWireRuntimeProto(proto)) return Location.get(CoreLoader.WIRE_RUNTIME_JAR, proto);
+      if (CoreLoader.INSTANCE.isWireRuntimeProto(proto)) {
+        return Location.get(CoreLoader.WIRE_RUNTIME_JAR, proto);
+      }
       throw new RuntimeException(new FileNotFoundException("Failed to locate " + proto + " in " + directories.keySet()));
     }
 

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -1,24 +1,12 @@
 package com.squareup.wire.mojo;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.io.Closer;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.wire.java.JavaGenerator;
-import com.squareup.wire.schema.PruningRules;
-import com.squareup.wire.schema.Location;
-import com.squareup.wire.schema.ProtoFile;
-import com.squareup.wire.schema.Schema;
-import com.squareup.wire.schema.SchemaLoader;
-import com.squareup.wire.schema.Type;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.squareup.wire.schema.*;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -26,6 +14,17 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
 
 /** A maven mojo that executes Wire's JavaGenerator. */
 @Mojo(name = "generate-sources", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
@@ -143,13 +142,28 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
     return result;
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   private Schema loadSchema(List<String> directories, List<String> protos) throws IOException {
     Stopwatch stopwatch = Stopwatch.createStarted();
 
-    SchemaLoader schemaLoader = new SchemaLoader(FileSystems.getDefault());
+    FileSystem fs = FileSystems.getDefault();
+    SchemaLoader schemaLoader = new SchemaLoader(fs);
 
-    schemaLoader.initRoots( directories.stream().map(Location::get).collect(Collectors.toList()),
-            protos.stream().map(Location::get).collect(Collectors.toList()) );
+    List<Path> sources = directories.stream().map(fs::getPath).collect(toList());
+    Map<Path, Path> directoryPaths = directoryPaths(Closer.create(), sources);
+
+    List<Location> allDirectories = directoryPaths.keySet().stream().map(Path::toString).map(Location::get).collect(toList());
+    List<Location> sourcePath;
+    List<Location> protoPath;
+
+    if (!protos.isEmpty()) {
+      sourcePath = protos.stream().map( it -> locationOfProto(directoryPaths, it) ).collect(toList());
+      protoPath = allDirectories;
+    } else {
+      sourcePath = allDirectories;
+      protoPath = List.of();
+    }
+    schemaLoader.initRoots( sourcePath, protoPath );
 
     Schema schema = schemaLoader.loadSchema();
 
@@ -157,6 +171,38 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
             schema.getProtoFiles().size(), stopwatch));
 
     return schema;
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  private static Map<Path, Path> directoryPaths(Closer closer, List<Path> sources )  {
+    Map<Path, Path> directories = new HashMap<>();
+    for (var source : sources) {
+      if (Files.isRegularFile(source)) {
+        FileSystem sourceFs;
+        try {
+          sourceFs = FileSystems.newFileSystem(source, WireGenerateSourcesMojo.class.getClassLoader());
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        closer.register(sourceFs);
+        directories.put(source, sourceFs.getRootDirectories().iterator().next());
+      } else {
+        directories.put(source, source);
+      }
+    }
+    return directories;
+  }
+
+  /** Searches {@code directories} trying to resolve {@code proto}. Returns the location if it is found. */
+  private static Location locationOfProto(Map<Path, Path> directories, String proto) {
+    Optional<Map.Entry<Path, Path>> directoryEntry = directories.entrySet().stream().filter(d -> Files.exists(d.getValue().resolve(proto))).findFirst();
+
+    if (directoryEntry.isEmpty()) {
+      if (CoreLoader.INSTANCE.isWireRuntimeProto(proto)) return Location.get(CoreLoader.WIRE_RUNTIME_JAR, proto);
+      throw new RuntimeException(new FileNotFoundException("Failed to locate " + proto + " in " + directories.keySet()));
+    }
+
+    return Location.get(directoryEntry.get().getKey().toString(), proto);
   }
 
   private void writeJavaFile(ClassName javaTypeName, TypeSpec typeSpec, Location location)

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -6,7 +6,28 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.wire.java.JavaGenerator;
-import com.squareup.wire.schema.*;
+import com.squareup.wire.schema.CoreLoader;
+import com.squareup.wire.schema.PruningRules;
+import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.ProtoFile;
+import com.squareup.wire.schema.Schema;
+import com.squareup.wire.schema.SchemaLoader;
+import com.squareup.wire.schema.Type;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -15,16 +36,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-
-import static java.util.stream.Collectors.toList;
 
 /** A maven mojo that executes Wire's JavaGenerator. */
 @Mojo(name = "generate-sources", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
@@ -149,15 +160,15 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
     FileSystem fs = FileSystems.getDefault();
     SchemaLoader schemaLoader = new SchemaLoader(fs);
 
-    List<Path> sources = directories.stream().map(fs::getPath).collect(toList());
+    List<Path> sources = directories.stream().map(fs::getPath).collect(Collectors.toList());
     Map<Path, Path> directoryPaths = directoryPaths(Closer.create(), sources);
 
-    List<Location> allDirectories = directoryPaths.keySet().stream().map(Path::toString).map(Location::get).collect(toList());
+    List<Location> allDirectories = directoryPaths.keySet().stream().map(Path::toString).map(Location::get).collect(Collectors.toList());
     List<Location> sourcePath;
     List<Location> protoPath;
 
     if (!protos.isEmpty()) {
-      sourcePath = protos.stream().map( it -> locationOfProto(directoryPaths, it) ).collect(toList());
+      sourcePath = protos.stream().map( it -> locationOfProto(directoryPaths, it) ).collect(Collectors.toList());
       protoPath = allDirectories;
     } else {
       sourcePath = allDirectories;


### PR DESCRIPTION
Resolve the actual proto file paths against the provided base directories before passing them to `SchemaLoader.initRoots()`. The code is taken pretty much like-for-like from `WireCompiler.kt`.